### PR TITLE
adds ccp-peglib to the list of repositories to clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ mkdir lattice-land
 cd lattice-land
 git clone https://github.com/NVIDIA/cccl.git
 git clone https://github.com/xcsp3team/XCSP3-CPP-Parser.git
+git clone git@github.com:yhirose/cpp-peglib.git
 git clone git@github.com:lattice-land/cuda-battery.git
 git clone git@github.com:lattice-land/lala-core.git
 git clone git@github.com:lattice-land/lattice-land.github.io.git

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ mkdir lattice-land
 cd lattice-land
 git clone https://github.com/NVIDIA/cccl.git
 git clone https://github.com/xcsp3team/XCSP3-CPP-Parser.git
-git clone git@github.com:yhirose/cpp-peglib.git
+git clone git@github.com:ptal/cpp-peglib.git
 git clone git@github.com:lattice-land/cuda-battery.git
 git clone git@github.com:lattice-land/lala-core.git
 git clone git@github.com:lattice-land/lattice-land.github.io.git


### PR DESCRIPTION
This PR adds `ccp-peglib` to the list of repositories to be cloned.